### PR TITLE
Add a simple validation when defining some values inside the Typecaster ...

### DIFF
--- a/lib/typecaster.rb
+++ b/lib/typecaster.rb
@@ -91,6 +91,8 @@ module Typecaster
   end
 
   def define_value(name, value)
+    raise "attribute #{name} is not defined" if attributes_options[name].nil?
+
     attributes_options[name][:value] = value
     value = typecasted_attribute(attributes_options[name])
     attributes[name] = value

--- a/spec/typecaster_spec.rb
+++ b/spec/typecaster_spec.rb
@@ -64,6 +64,14 @@ describe Typecaster do
         expect(subject.to_s).to eq "Ricardo   023R         "
       end
     end
+
+    context "with invalid values" do
+      it "should raise an error for the invalid field" do
+        expect(lambda {
+          ObjectFormatter.new(:name => "Ricardo", :age => 23, :xpto => "R")
+        }).to raise_error("attribute xpto is not defined")
+      end
+    end
   end
 
   context "parsing" do


### PR DESCRIPTION
...object

Sometimes we make some typos when writing a new object
in greater objects is harder to find where it happens.
this validation checks with a friendly message instead the ugly

```
NoMethodError:
   undefined method `[]=' for nil:NilClass
```

now it will raise something like that

```
attribute xpto is not defined
```
