### PR TITLE
Add attribute name to caster options hash

### DIFF
--- a/lib/typecaster.rb
+++ b/lib/typecaster.rb
@@ -125,6 +125,7 @@ module Typecaster
     raise "attribute #{name} is not defined" if attributes_options[name].nil?
 
     attributes_options[name][:value] = value
+    attributes_options[name][:attribute] = name
     value = typecasted_attribute(attributes_options[name])
     attributes[name] = value
   end

--- a/spec/typecaster_spec.rb
+++ b/spec/typecaster_spec.rb
@@ -61,6 +61,14 @@ describe Typecaster do
         ObjectFormatter.new(:name => "Ricardo", :age => 23, :identification => "R")
       end
 
+      it "calls the caster class with the attribute options" do
+        attributes = { :default => "*", :caster => StringTypecaster, :size => 10, :value => "*", :attribute => :identification }
+
+        StringTypecaster.should_receive(:call).with("*", attributes)
+
+        ObjectFormatter.new
+      end
+
       it "should return formatted name" do
         expect(subject.attributes[:name]).to eq "Ricardo   "
       end


### PR DESCRIPTION
This change makes the attribute name available to the typecaster objects
through the `options` hash, as `options[:attribute]`. This is useful for
raising errors in the caster object, and including the attribute name
in the error message, which makes debugging much easier.
